### PR TITLE
For make: fix bitstream same name as folder, remove auto-clean

### DIFF
--- a/boards/RFSoC2x2/rfsoc_ofdm/Makefile
+++ b/boards/RFSoC2x2/rfsoc_ofdm/Makefile
@@ -1,9 +1,9 @@
-all: block_design bitstream clean
+all: block_design make_bitstream
 
 block_design:
 	vivado -mode batch -source make_block_design.tcl -notrace
 
-bitstream:
+make_bitstream:
 	vivado -mode batch -source make_bitstream.tcl -notrace
 
 clean:

--- a/boards/RFSoC4x2/rfsoc_ofdm/makefile
+++ b/boards/RFSoC4x2/rfsoc_ofdm/makefile
@@ -1,9 +1,9 @@
-all: block_design bitstream clean
+all: block_design make_bitstream
 
 block_design:
 	vivado -mode batch -source make_block_design.tcl -notrace
 
-bitstream:
+make_bitstream:
 	vivado -mode batch -source make_bitstream.tcl -notrace
 
 clean:

--- a/boards/ZCU111/rfsoc_ofdm/Makefile
+++ b/boards/ZCU111/rfsoc_ofdm/Makefile
@@ -1,9 +1,9 @@
-all: block_design bitstream clean
+all: block_design make_bitstream 
 
 block_design:
 	vivado -mode batch -source make_block_design.tcl -notrace
 
-bitstream:
+make_bitstream:
 	vivado -mode batch -source make_bitstream.tcl -notrace
 
 clean:


### PR DESCRIPTION
The Makefiles have a target name same as a folder name: 'bitstream'.  This prevents the bitstreams from being rebuilt under Linux.

Could add .PHONY, or modify .tcl for a different folder but I simply changed the target name to 'make_bitstream'.

Feel free to reject my removal of 'clean' under 'all'.  I wanted to look at the block design after I built the bitstream :-)

Kind regards,
-Fred